### PR TITLE
Fixed wrong cameraSpeed in Level.java

### DIFF
--- a/src/com/thecherno/ld34/Level.java
+++ b/src/com/thecherno/ld34/Level.java
@@ -156,7 +156,7 @@ public class Level {
 					speedUpMessage();
 				}
 				tier = 1;
-				cameraSpeed = 10;
+				cameraSpeed = 3;
 			}
 			
 			for (int i = 0; i < cameraSpeed; i++) {


### PR DESCRIPTION
Fixed wrong cameraSpeed for tier 1.
It is now 3 instead of 10
